### PR TITLE
Fix for strict error Declaration of FileStorageBehavior::beforeSave()...

### DIFF
--- a/Model/Behavior/FileStorageBehavior.php
+++ b/Model/Behavior/FileStorageBehavior.php
@@ -85,7 +85,7 @@ class FileStorageBehavior extends ModelBehavior
 	 *
 	 * @return bool Whether file has saved successfully
 	 */
-	public function beforeSave(Model $model)
+	public function beforeSave(Model $model, $options = array())
 	{
 		if ($file_data = $this->getFileDataFromForm($model)) {
 


### PR DESCRIPTION
This commit fixes this error:
Strict (2048): Declaration of FileStorageBehavior::beforeSave() should be compatible with ModelBehavior::beforeSave(Model $model, $options = Array) [APP/Plugin/CakeFileStorage/Model/Behavior/FileStorageBehavior.php, line 0]
